### PR TITLE
Polling Pty late initialisation (no closures)

### DIFF
--- a/lib/pty.dart
+++ b/lib/pty.dart
@@ -19,6 +19,7 @@ abstract class PseudoTerminal {
     String? workingDirectory,
     Map<String, String>? environment,
     bool blocking = false,
+    bool ackProcessed = false,
     // bool includeParentEnvironment = true,
     // bool runInShell = false,
     // ProcessStartMode mode = ProcessStartMode.normal,
@@ -48,7 +49,7 @@ abstract class PseudoTerminal {
     }
 
     if (blocking) {
-      return BlockingPseudoTerminal(core);
+      return BlockingPseudoTerminal(core, ackProcessed);
     } else {
       return PollingPseudoTerminal(core);
     }
@@ -66,6 +67,8 @@ abstract class PseudoTerminal {
   void write(String input);
 
   Stream<String> get out;
+
+  void ackProcessed();
 
   void resize(int width, int height);
 }

--- a/lib/pty.dart
+++ b/lib/pty.dart
@@ -54,6 +54,7 @@ abstract class PseudoTerminal {
     }
   }
 
+  void init();
   bool kill([ProcessSignal signal = ProcessSignal.sigterm]);
 
   Future<int> get exitCode;

--- a/lib/src/pty.dart
+++ b/lib/src/pty.dart
@@ -114,15 +114,13 @@ class BlockingPseudoTerminal extends BasePseudoTerminal {
   late final StreamController<String> _outStreamController;
 
   @override
-  void init() async {
+  void init() {
     _outStreamController = StreamController<String>();
     out = _outStreamController.stream;
 
     final receivePort = ReceivePort();
-    await Isolate.spawn(_readUntilExit,
-        _IsolateArgs(receivePort.sendPort, _core, _syncProcessed));
-    bool first = true;
-    await for (var msg in receivePort) {
+    var first = true;
+    receivePort.listen((msg) {
       if (first) {
         _sendPort = msg;
         _sendPort.send(true);
@@ -130,7 +128,9 @@ class BlockingPseudoTerminal extends BasePseudoTerminal {
         _outStreamController.sink.add(msg);
       }
       first = false;
-    }
+    });
+    Isolate.spawn(_readUntilExit,
+        _IsolateArgs(receivePort.sendPort, _core, _syncProcessed));
   }
 
   @override

--- a/lib/src/pty.dart
+++ b/lib/src/pty.dart
@@ -49,7 +49,7 @@ class PollingPseudoTerminal extends BasePseudoTerminal {
     _exitCode = Completer<int>();
     _out = StreamController<String>();
     _initialized = true;
-    Timer.periodic(Duration(milliseconds: 1), _poll);
+    Timer.periodic(Duration(milliseconds: 5), _poll);
   }
 
   void _poll(Timer timer) {

--- a/lib/src/pty.dart
+++ b/lib/src/pty.dart
@@ -56,13 +56,12 @@ class PollingPseudoTerminal extends BasePseudoTerminal {
   List<int> _createDelayMicrosecondsStepList(
       Map<int, int> delayMicrosecondsToAmountMap) {
     final result = List<int>.empty(growable: true);
-    final maxVal = delayMicrosecondsToAmountMap.keys.fold(
-        1,
-        (int previousValue, int element) =>
-            (element > previousValue) ? element : previousValue);
-    for (var i = 1; i <= maxVal; i++) {
-      if (delayMicrosecondsToAmountMap.containsKey(i)) {
-        result.addAll(List<int>.filled(delayMicrosecondsToAmountMap[i]!, i));
+    final sortedKeys = delayMicrosecondsToAmountMap.keys.toList(growable: false)
+      ..sort();
+    for (final key in sortedKeys) {
+      if (delayMicrosecondsToAmountMap.containsKey(key)) {
+        result
+            .addAll(List<int>.filled(delayMicrosecondsToAmountMap[key]!, key));
       }
     }
     return result;
@@ -115,7 +114,7 @@ class PollingPseudoTerminal extends BasePseudoTerminal {
       }
 
       if (_initialized) {
-        if (receivedSomething && rawDataBuffer.isNotEmpty) {
+        if (rawDataBuffer.isNotEmpty) {
           try {
             final strContent = utf8.decode(rawDataBuffer);
             rawDataBuffer.clear();

--- a/lib/src/pty.dart
+++ b/lib/src/pty.dart
@@ -123,7 +123,6 @@ class BlockingPseudoTerminal extends BasePseudoTerminal {
     receivePort.listen((msg) {
       if (first) {
         _sendPort = msg;
-        _sendPort.send(true);
       } else {
         _outStreamController.sink.add(msg);
       }
@@ -181,9 +180,12 @@ void _readUntilExit(_IsolateArgs<PtyCore> ctx) async {
 
   final loopController = StreamController<bool>();
 
-  rp.listen((message) {
-    loopController.sink.add(message);
-  });
+  if (ctx.syncProcessed) {
+    rp.listen((message) {
+      loopController.sink.add(message);
+    });
+  }
+  loopController.sink.add(true); //enable the first iteration
 
   await for (final _ in loopController.stream) {
     final data = ctx.arg.read();
@@ -203,4 +205,5 @@ void _readUntilExit(_IsolateArgs<PtyCore> ctx) async {
       loopController.sink.add(true);
     }
   }
+  await loopController.close();
 }

--- a/lib/src/pty.dart
+++ b/lib/src/pty.dart
@@ -59,10 +59,7 @@ class PollingPseudoTerminal extends BasePseudoTerminal {
     final sortedKeys = delayMicrosecondsToAmountMap.keys.toList(growable: false)
       ..sort();
     for (final key in sortedKeys) {
-      if (delayMicrosecondsToAmountMap.containsKey(key)) {
-        result
-            .addAll(List<int>.filled(delayMicrosecondsToAmountMap[key]!, key));
-      }
+      result.addAll(List<int>.filled(delayMicrosecondsToAmountMap[key]!, key));
     }
     return result;
   }

--- a/lib/src/pty.dart
+++ b/lib/src/pty.dart
@@ -102,14 +102,14 @@ class PollingPseudoTerminal extends BasePseudoTerminal {
 /// flutter hot reload from working. Ideal for release builds. The underlying
 /// PtyCore must be blocking.
 class BlockingPseudoTerminal extends BasePseudoTerminal {
-  BlockingPseudoTerminal(PtyCore _core) : super(_core) {
+  BlockingPseudoTerminal(PtyCore _core) : super(_core);
+
+  @override
+  void init() {
     final receivePort = ReceivePort();
     Isolate.spawn(_readUntilExit, _IsolateArgs(receivePort.sendPort, _core));
     out = receivePort.cast();
   }
-
-  @override
-  void init() {}
 
   @override
   Future<int> get exitCode async {


### PR DESCRIPTION
reduce polling time to 1ms (would be better configurable)

This PR is used by 
xterm: https://github.com/TerminalStudio/xterm.dart/pull/34
studio: https://github.com/TerminalStudio/studio/pull/1