### PR TITLE
Decouples the check for the exit code from the (high frequency) data polling

### DIFF
--- a/lib/src/pty.dart
+++ b/lib/src/pty.dart
@@ -82,14 +82,22 @@ class PollingPseudoTerminal extends BasePseudoTerminal {
 
     var delayStepIndex = 0;
 
+    var exitCodeCheckNeeded = true;
+
     final rawDataBuffer = List<int>.empty(growable: true);
 
     while (true) {
-      final exit = _core.exitCodeNonBlocking();
-      if (exit != null) {
-        _exitCode.complete(exit);
-        await _out.close();
-        return;
+      if (exitCodeCheckNeeded) {
+        final exit = _core.exitCodeNonBlocking();
+        if (exit != null) {
+          _exitCode.complete(exit);
+          await _out.close();
+          return;
+        }
+        exitCodeCheckNeeded = false;
+        Timer(Duration(milliseconds: 500), () {
+          exitCodeCheckNeeded = true;
+        });
       }
 
       var receivedSomething = false;


### PR DESCRIPTION
This PR moves the exit code check behind a flag that gets flipped by a Timer in order to avoid having the check being part during the data read polling.
The polling can be very high frequent so checking the exit code at that same frequency is not necessary and wastes a lot of CPU time.